### PR TITLE
Parallel column computation via Rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["spectrogram", "spectrograph", "audio", "fft", "dft"]
 categories = ["multimedia::images", "science", "multimedia::audio", "visualization"]
 
 [features]
-default = [ "hound", "png" ]
+default = [ "hound", "png", "rayon" ]
 build-binary = ["clap"]
 
 [[bin]]
@@ -26,3 +26,4 @@ csv = "1.1"
 rustfft = "6.0"
 resize = "0.7.2"
 rgb = "0.8.25"
+rayon = { version = "1.5.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sonogram"
 description = "A spectrograph utility written in Rust"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Simon M. Werner <simonwerner@gmail.com>"]
 license = "GPL-3.0-or-later"
 readme = "README.md"
@@ -26,4 +26,4 @@ csv = "1.1"
 rustfft = "6.0"
 resize = "0.7.2"
 rgb = "0.8.25"
-rayon = { version = "1.5.3", optional = true }
+rayon = { version = "1.7.0", optional = true }

--- a/src/bin/sonogram/main.rs
+++ b/src/bin/sonogram/main.rs
@@ -175,15 +175,10 @@ fn main() {
     //
     // Do the spectrograph
     //
-    let mut spectrograph =
     #[cfg(feature = "rayon")]
-    {
-        spec_builder.build().unwrap().par_compute(None)
-    };
+    let mut spectrograph = spec_builder.build().unwrap().par_compute(None);
     #[cfg(not(feature = "rayon"))]
-    {
-        spec_builder.build().unwrap().compute()
-    };
+    let mut spectrograph = spec_builder.build().unwrap().compute();
 
     if args.png.is_some() {
         spectrograph

--- a/src/bin/sonogram/main.rs
+++ b/src/bin/sonogram/main.rs
@@ -175,7 +175,15 @@ fn main() {
     //
     // Do the spectrograph
     //
-    let mut spectrograph = spec_builder.build().unwrap().compute();
+    let mut spectrograph =
+    #[cfg(feature = "rayon")]
+    {
+        spec_builder.build().unwrap().par_compute(None)
+    };
+    #[cfg(not(feature = "rayon"))]
+    {
+        spec_builder.build().unwrap().compute()
+    };
 
     if args.png.is_some() {
         spectrograph

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,14 @@ impl Spectrogram {
         // Convert the buffer to dB
         to_db(&mut buf);
 
+        println!(
+            "buf len: {} ({} {}) -> ({} {})",
+            buf.len(),
+            self.width,
+            self.height,
+            img_width,
+            img_height
+        );
         resize(&buf, self.width, self.height, img_width, img_height)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl Spectrogram {
         self.buf_to_img(&buf, &mut img, gradient);
 
         let mut pngbuf: Vec<u8> = Vec::new();
-        let mut encoder = png::Encoder::new(&mut pngbuf, img.len() as u32, self.height as u32);
+        let mut encoder = png::Encoder::new(&mut pngbuf, w_img as u32, h_img as u32);
         encoder.set(png::ColorType::RGBA).set(png::BitDepth::Eight);
         let mut writer = encoder.write_header()?;
         writer.write_image_data(&img)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,14 +249,6 @@ impl Spectrogram {
         // Convert the buffer to dB
         to_db(&mut buf);
 
-        println!(
-            "buf len: {} ({} {}) -> ({} {})",
-            buf.len(),
-            self.width,
-            self.height,
-            img_width,
-            img_height
-        );
         resize(&buf, self.width, self.height, img_width, img_height)
     }
 

--- a/src/spec_core.rs
+++ b/src/spec_core.rs
@@ -153,8 +153,6 @@ impl SpecCompute {
             p += self.step_size;
         }
 
-        println!("Computed spectrogram with {} ({}, {})", spec.len(), height, width);
-
         Spectrogram {
             spec,
             width,

--- a/src/spec_core.rs
+++ b/src/spec_core.rs
@@ -17,11 +17,14 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-use std::sync::Arc;
+use std::sync::{Arc};
 use std::{cmp::min, f32};
 
 use crate::{Spectrogram, WindowFn};
 use rustfft::{num_complex::Complex, FftPlanner};
+
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 
 ///
 /// This contains all the initialised data.  This can then produce the spectrogram,
@@ -45,7 +48,10 @@ pub struct SpecCompute {
     data: Vec<f32>,      // The time domain data for the FFT.  Normalised to meet -1.0..1.0.
     window_fn: WindowFn, // The Window Function to apply to each fft window.
     step_size: usize, // The step size in the window function, must be less than the window function
-    fft_fn: Arc<dyn rustfft::Fft<f32>>,
+    fft_fn: Arc<dyn rustfft::Fft<f32>>, // An FFT function that can be used to compute the FFT.
+
+    #[cfg(feature = "rayon")]
+    gen_fft_fn: Arc<dyn Sync + Send + Fn() -> Arc<dyn rustfft::Fft<f32>>>, // An FFT generator for each thread
 }
 
 impl SpecCompute {
@@ -53,16 +59,36 @@ impl SpecCompute {
     ///
     /// **You probably want to use [SpecOptionsBuilder] instead.**
     pub fn new(num_bins: usize, step_size: usize, data: Vec<f32>, window_fn: WindowFn) -> Self {
-        // Compute the FFT plan
-        let mut planner = FftPlanner::<f32>::new();
-        let fft_fn = planner.plan_fft_forward(num_bins);
+        // Compute the FFT plan generator and a single FFT plan, if supporting parallel FFTs.
+        #[cfg(feature = "rayon")]
+        {
+            let gen_fft_fn = Arc::new(move || {
+                let mut planner = FftPlanner::new();
+                planner.plan_fft_forward(num_bins)
+            });
+            let fft_fn = gen_fft_fn();
+            SpecCompute {
+                num_bins,
+                step_size,
+                data,
+                window_fn,
+                fft_fn,
+                gen_fft_fn,
+            }
+        }
 
-        SpecCompute {
-            num_bins,
-            step_size,
-            data,
-            window_fn,
-            fft_fn,
+        // Compute a single FFT plan, if not supporting parallel FFTs.
+        #[cfg(not(feature = "rayon"))]
+        {
+            let mut planner = FftPlanner::<f32>::new();
+            let fft_fn = planner.plan_fft_forward(num_bins);
+            SpecCompute {
+                num_bins,
+                step_size,
+                data,
+                window_fn,
+                fft_fn,
+            }
         }
     }
 
@@ -126,6 +152,106 @@ impl SpecCompute {
 
             p += self.step_size;
         }
+
+        println!("Computed spectrogram with {} ({}, {})", spec.len(), height, width);
+
+        Spectrogram {
+            spec,
+            width,
+            height,
+        }
+    }
+
+    ///
+    /// Do the discrete fourier transform to create the spectrogram.
+    /// 
+    /// This function will use rayon to parallelize the FFT computation.
+    /// It may create more FFT plans than there are threads, but will reuse them 
+    /// if called multiple times.
+    ///
+    ///
+    /// # Arguments
+    /// 
+    ///  * `self` -  `self` is immutable so that the FFT plans can be shared between threads.
+    ///               Since the FFT plans are not thread safe, they are wrapped in a Mutex. 
+    ///
+    ///  * `data` -  The time domain data to compute the spectrogram from.
+    ///              `data` is not preprocessed other than windowing and 
+    ///               casting to complex.
+    ///
+    #[cfg(feature = "rayon")]
+    pub fn par_compute(&self, data: &[f32]) -> Spectrogram {
+        use std::cell::RefCell;
+
+        let width = (data.len() - self.num_bins) / self.step_size;
+        let height = self.num_bins / 2;
+
+        // Compute the spectrogram in parallel steps via rayon
+        let spec_cols: Vec<_> = (0..width)
+            .into_par_iter()
+            .map(
+                |w| {
+                    // Grab the FFT for this thread
+                    thread_local! {
+                        pub static FFT_FN: RefCell<Option<Arc<dyn rustfft::Fft<f32>>>> = RefCell::new(None);
+                        pub static INPLACE_BUF: RefCell<Option<Vec<Complex<f32>>>> = RefCell::new(None);
+                        pub static SCRATCH_BUF: RefCell<Option<Vec<Complex<f32>>>> = RefCell::new(None);
+                    }
+
+                    // Index to the beginning of the window
+                    let window_index = w * self.step_size;
+
+                    // All the computation on the column happens in this thread where we have exclusive access to the memory
+                    let spec_col = FFT_FN.with(|fft_fn| {
+                        let fft_fn = fft_fn.borrow_mut().get_or_insert_with(|| (self.gen_fft_fn)()).clone();
+                        INPLACE_BUF.with(|inplace_buf| {
+                            let mut inplace_buf_ref = inplace_buf.borrow_mut();
+                            let inplace_buf = inplace_buf_ref.get_or_insert_with(|| vec![Complex::new(0., 0.); self.num_bins]);
+                            SCRATCH_BUF.with(|scratch_buf| {
+                                let mut scratch_buf_ref = scratch_buf.borrow_mut();
+                                let scratch_buf = scratch_buf_ref.get_or_insert_with(|| vec![Complex::new(0., 0.); fft_fn.get_inplace_scratch_len()]);
+
+                                // Extract the next `num_bins` complex floats into the FFT inplace compute buffer
+                                data[(w * self.step_size)..]
+                                .iter()
+                                .take(self.num_bins)
+                                .enumerate()
+                                .map(|(i, val)| Complex::new(val * (self.window_fn)(i, self.num_bins), 0.))
+                                .zip(inplace_buf.iter_mut())
+                                .for_each(|(c, v)| *v = c);
+            
+                                // Create slices into the buffers backing the Vecs to be reused on each loop
+                                let inplace_slice = inplace_buf.as_mut_slice();
+                                let scratch_slice = scratch_buf.as_mut_slice();
+            
+                                // Call out to rustfft to actually compute the FFT
+                                // This will take the inplace_slice as input, use scratch_slice during computation, and write FFT back into inplace_slice
+                                let inplace =
+                                    &mut inplace_slice[..min(self.num_bins, data.len() - window_index)];
+                                fft_fn.process_with_scratch(inplace, scratch_slice);
+            
+                                // Normalize the spectrogram and write to the output
+                                inplace
+                                    .iter()
+                                    .take(height)
+                                    .rev()
+                                    .map(|c_val| c_val.norm())
+                                    .collect::<Vec<_>>()
+                            })
+                        })
+                    });
+
+                    spec_col
+                },
+            )
+            .collect();
+
+
+        // Transpose the columns into row major order
+        let spec = (0..height)
+            .into_par_iter()
+            .flat_map_iter(|i| spec_cols.iter().map(move |row| row[i]))
+            .collect::<Vec<_>>();
 
         Spectrogram {
             spec,

--- a/src/spec_core.rs
+++ b/src/spec_core.rs
@@ -17,7 +17,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-use std::sync::{Arc};
+use std::sync::Arc;
 use std::{cmp::min, f32};
 
 use crate::{Spectrogram, WindowFn};
@@ -178,7 +178,8 @@ impl SpecCompute {
     ///               casting to complex.
     ///
     #[cfg(feature = "rayon")]
-    pub fn par_compute(&self, data: &[f32]) -> Spectrogram {
+    pub fn par_compute(&self, data: Option<&[f32]>) -> Spectrogram {
+        let data = data.unwrap_or(self.data.as_slice());
         let width = (data.len() - self.num_bins) / self.step_size;
         let height = self.num_bins / 2;
 


### PR DESCRIPTION
This PR generates a per thread FFT fn and computation buffer. It is reused per thread via thread_local, so it is only compatible with one configuration of SpecCompute until thread local metadata is moved into SpecCompute